### PR TITLE
Add tensor concatenation and stacking operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,4 +33,7 @@ if(BUILD_EXAMPLES)
 
     add_executable(slicing_broadcasting_demo examples/slicing_broadcasting_demo.cpp)
     target_link_libraries(slicing_broadcasting_demo PRIVATE eigenwave)
+
+    add_executable(concatenate_demo examples/concatenate_demo.cpp)
+    target_link_libraries(concatenate_demo PRIVATE eigenwave)
 endif()

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ make -j
 #include <eigenwave/operations.hpp>
 #include <eigenwave/slicing.hpp>
 #include <eigenwave/broadcasting.hpp>
+#include <eigenwave/concatenate.hpp>
 
 using namespace eigenwave;
 
@@ -125,11 +126,16 @@ int main() {
 - **O(1) broadcast views** - Broadcasting creates views, not copies
 - Automatic broadcasting in arithmetic operations
 - `BroadcastView` - Virtual broadcasting without data duplication
-- `broadcast_1d_to_2d_cols()` - Broadcast vector to matrix columns
-- `broadcast_1d_to_2d_rows()` - Broadcast vector to matrix rows
 - `reshape()` - Change tensor dimensions (preserving size)
 - `expand_dims_front/back()` - Add singleton dimensions
 - `squeeze()` - Remove singleton dimensions
+
+### Concatenation and Stacking
+- `concatenate()` - Join tensors along an existing axis
+- `stack()` - Join tensors along a new axis
+- `hstack()` - Horizontal stack (column-wise for 2D)
+- `vstack()` - Vertical stack (row-wise for 2D)
+- `dstack()` - Depth stack (along third axis)
 
 ## Technical Documentation
 
@@ -224,6 +230,34 @@ auto expanded = expand_dims_front(vec1d);  // Shape: [1, 3]
 auto squeezed = squeeze(expanded);         // Back to shape: [3]
 ```
 
+### Concatenation Examples
+
+```cpp
+// Concatenating 1D tensors
+Tensor<int, 3> vec1{1, 2, 3};
+Tensor<int, 2> vec2{4, 5};
+auto concat = concatenate(vec1, vec2);  // Shape: [5]
+
+// Concatenating 2D tensors along different axes
+Tensor<float, 2, 3> mat1{1, 2, 3, 4, 5, 6};
+Tensor<float, 1, 3> mat2{7, 8, 9};
+auto vconcat = concatenate<0>(mat1, mat2);  // Shape: [3, 3] - along rows
+
+Tensor<float, 2, 2> mat3{1, 2, 3, 4};
+Tensor<float, 2, 1> mat4{5, 6};
+auto hconcat = concatenate<1>(mat3, mat4);  // Shape: [2, 3] - along cols
+
+// Stacking creates a new axis
+Tensor<int, 3> v1{1, 2, 3};
+Tensor<int, 3> v2{4, 5, 6};
+auto stacked = stack(v1, v2);  // Shape: [2, 3]
+
+// Convenience functions
+auto h_result = hstack(vec1, vec2);  // Horizontal concatenation
+auto v_result = vstack(v1, v2);      // Vertical stacking
+auto d_result = dstack(mat3, mat3);  // Depth stacking
+```
+
 ## Design Philosophy
 
 EigenWave prioritizes compile-time safety and zero-cost abstractions. All dimension checking happens at compile time, meaning:
@@ -250,4 +284,3 @@ Planned features for future versions:
 - GPU acceleration support
 - Automatic differentiation
 - Einsum operations
-- Tensor concatenation and stacking

--- a/examples/concatenate_demo.cpp
+++ b/examples/concatenate_demo.cpp
@@ -1,0 +1,238 @@
+#include <eigenwave/tensor.hpp>
+#include <eigenwave/concatenate.hpp>
+#include <iostream>
+#include <iomanip>
+
+using namespace eigenwave;
+
+int main() {
+    std::cout << "=== EigenWave: Tensor Concatenation and Stacking Demo ===" << std::endl << std::endl;
+
+    // ========== 1D CONCATENATION ==========
+    std::cout << "1. ONE-DIMENSIONAL CONCATENATION" << std::endl;
+    std::cout << "=================================" << std::endl << std::endl;
+
+    Tensor<int, 3> vec1{1, 2, 3};
+    Tensor<int, 4> vec2{4, 5, 6, 7};
+    Tensor<int, 2> vec3{8, 9};
+
+    std::cout << "Vector 1: ";
+    vec1.print();
+    std::cout << "Vector 2: ";
+    vec2.print();
+    std::cout << "Vector 3: ";
+    vec3.print();
+
+    auto concat_1d = concatenate(vec1, vec2, vec3);
+    std::cout << "Concatenated result: ";
+    concat_1d.print();
+    std::cout << std::endl;
+
+    // ========== 2D CONCATENATION ==========
+    std::cout << "2. TWO-DIMENSIONAL CONCATENATION" << std::endl;
+    std::cout << "=================================" << std::endl << std::endl;
+
+    Tensor<float, 2, 3> mat1{1.0f, 2.0f, 3.0f,
+                             4.0f, 5.0f, 6.0f};
+
+    Tensor<float, 1, 3> mat2{7.0f, 8.0f, 9.0f};
+
+    std::cout << "Matrix 1 (2x3):" << std::endl;
+    mat1.print();
+
+    std::cout << "Matrix 2 (1x3):" << std::endl;
+    mat2.print();
+
+    // Concatenate along axis 0 (rows)
+    auto concat_axis0 = concatenate<0>(mat1, mat2);
+    std::cout << "Concatenated along axis 0 (vertical):" << std::endl;
+    concat_axis0.print();
+
+    // Concatenate along axis 1 (columns)
+    Tensor<float, 2, 2> mat3{10.0f, 11.0f,
+                             12.0f, 13.0f};
+
+    std::cout << "Matrix 3 (2x2):" << std::endl;
+    mat3.print();
+
+    auto concat_axis1 = concatenate<1>(mat1, mat3);
+    std::cout << "Matrix 1 concatenated with Matrix 3 along axis 1 (horizontal):" << std::endl;
+    concat_axis1.print();
+    std::cout << std::endl;
+
+    // ========== STACKING ==========
+    std::cout << "3. TENSOR STACKING" << std::endl;
+    std::cout << "==================" << std::endl << std::endl;
+
+    Tensor<int, 4> stack_vec1{1, 2, 3, 4};
+    Tensor<int, 4> stack_vec2{5, 6, 7, 8};
+    Tensor<int, 4> stack_vec3{9, 10, 11, 12};
+
+    std::cout << "Three vectors to stack:" << std::endl;
+    std::cout << "Vec 1: ";
+    stack_vec1.print();
+    std::cout << "Vec 2: ";
+    stack_vec2.print();
+    std::cout << "Vec 3: ";
+    stack_vec3.print();
+
+    auto stacked = stack(stack_vec1, stack_vec2, stack_vec3);
+    std::cout << "Stacked into 3x4 matrix:" << std::endl;
+    stacked.print();
+    std::cout << std::endl;
+
+    // Stack 2D matrices to create 3D tensor
+    Tensor<int, 2, 2> stack_mat1{1, 2,
+                                  3, 4};
+    Tensor<int, 2, 2> stack_mat2{5, 6,
+                                  7, 8};
+
+    std::cout << "Stack two 2x2 matrices:" << std::endl;
+    std::cout << "Matrix 1:" << std::endl;
+    stack_mat1.print();
+    std::cout << "Matrix 2:" << std::endl;
+    stack_mat2.print();
+
+    auto stacked_3d = stack(stack_mat1, stack_mat2);
+    std::cout << "Stacked into 2x2x2 tensor:" << std::endl;
+    stacked_3d.print();
+    std::cout << std::endl;
+
+    // ========== CONVENIENCE FUNCTIONS ==========
+    std::cout << "4. CONVENIENCE FUNCTIONS" << std::endl;
+    std::cout << "========================" << std::endl << std::endl;
+
+    // hstack (horizontal stack)
+    std::cout << "4.1 Horizontal Stack (hstack):" << std::endl;
+    std::cout << "-------------------------------" << std::endl;
+
+    Tensor<float, 3> h_vec1{1.0f, 2.0f, 3.0f};
+    Tensor<float, 2> h_vec2{4.0f, 5.0f};
+
+    std::cout << "hstack of two 1D vectors:" << std::endl;
+    std::cout << "Vec 1: ";
+    h_vec1.print();
+    std::cout << "Vec 2: ";
+    h_vec2.print();
+
+    auto hstacked = hstack(h_vec1, h_vec2);
+    std::cout << "Result: ";
+    hstacked.print();
+    std::cout << std::endl;
+
+    Tensor<float, 2, 2> h_mat1{1.0f, 2.0f,
+                               3.0f, 4.0f};
+    Tensor<float, 2, 3> h_mat2{5.0f, 6.0f, 7.0f,
+                               8.0f, 9.0f, 10.0f};
+
+    std::cout << "hstack of two 2D matrices:" << std::endl;
+    std::cout << "Matrix 1 (2x2):" << std::endl;
+    h_mat1.print();
+    std::cout << "Matrix 2 (2x3):" << std::endl;
+    h_mat2.print();
+
+    auto hstacked_2d = hstack(h_mat1, h_mat2);
+    std::cout << "Result (2x5):" << std::endl;
+    hstacked_2d.print();
+    std::cout << std::endl;
+
+    // vstack (vertical stack)
+    std::cout << "4.2 Vertical Stack (vstack):" << std::endl;
+    std::cout << "-----------------------------" << std::endl;
+
+    Tensor<int, 3> v_vec1{1, 2, 3};
+    Tensor<int, 3> v_vec2{4, 5, 6};
+
+    std::cout << "vstack of two 1D vectors (creates new axis):" << std::endl;
+    std::cout << "Vec 1: ";
+    v_vec1.print();
+    std::cout << "Vec 2: ";
+    v_vec2.print();
+
+    auto vstacked = vstack(v_vec1, v_vec2);
+    std::cout << "Result (2x3 matrix):" << std::endl;
+    vstacked.print();
+    std::cout << std::endl;
+
+    Tensor<int, 2, 3> v_mat1{1, 2, 3,
+                             4, 5, 6};
+    Tensor<int, 1, 3> v_mat2{7, 8, 9};
+
+    std::cout << "vstack of two 2D matrices:" << std::endl;
+    std::cout << "Matrix 1 (2x3):" << std::endl;
+    v_mat1.print();
+    std::cout << "Matrix 2 (1x3):" << std::endl;
+    v_mat2.print();
+
+    auto vstacked_2d = vstack(v_mat1, v_mat2);
+    std::cout << "Result (3x3):" << std::endl;
+    vstacked_2d.print();
+    std::cout << std::endl;
+
+    // dstack (depth stack)
+    std::cout << "4.3 Depth Stack (dstack):" << std::endl;
+    std::cout << "-------------------------" << std::endl;
+
+    Tensor<float, 2, 2> d_mat1{1.0f, 2.0f,
+                               3.0f, 4.0f};
+    Tensor<float, 2, 2> d_mat2{5.0f, 6.0f,
+                               7.0f, 8.0f};
+
+    std::cout << "dstack of two 2x2 matrices:" << std::endl;
+    std::cout << "Matrix 1:" << std::endl;
+    d_mat1.print();
+    std::cout << "Matrix 2:" << std::endl;
+    d_mat2.print();
+
+    auto dstacked = dstack(d_mat1, d_mat2);
+    std::cout << "Result (2x2x2 tensor):" << std::endl;
+    dstacked.print();
+    std::cout << std::endl;
+
+    // ========== PRACTICAL EXAMPLE ==========
+    std::cout << "5. PRACTICAL EXAMPLE: BATCH PROCESSING" << std::endl;
+    std::cout << "=======================================" << std::endl << std::endl;
+
+    // Simulate collecting data batches
+    std::cout << "Collecting sensor data in batches..." << std::endl;
+
+    Tensor<float, 3> batch1{1.1f, 2.2f, 3.3f};  // First batch of 3 readings
+    Tensor<float, 3> batch2{4.4f, 5.5f, 6.6f};  // Second batch
+    Tensor<float, 3> batch3{7.7f, 8.8f, 9.9f};  // Third batch
+
+    std::cout << "Batch 1: ";
+    batch1.print();
+    std::cout << "Batch 2: ";
+    batch2.print();
+    std::cout << "Batch 3: ";
+    batch3.print();
+
+    // Stack batches to create a time series matrix
+    auto time_series = stack(batch1, batch2, batch3);
+    std::cout << "Combined time series (3 time steps x 3 sensors):" << std::endl;
+    time_series.print();
+
+    // Compute statistics across time (rows) for each sensor
+    std::cout << "\nStatistics for each sensor:" << std::endl;
+    for (size_t sensor = 0; sensor < 3; ++sensor) {
+        float sum = 0;
+        float min_val = time_series(0, sensor);
+        float max_val = time_series(0, sensor);
+
+        for (size_t time = 0; time < 3; ++time) {
+            float val = time_series(time, sensor);
+            sum += val;
+            if (val < min_val) min_val = val;
+            if (val > max_val) max_val = val;
+        }
+
+        std::cout << "Sensor " << sensor << ": "
+                  << "mean=" << std::fixed << std::setprecision(2) << (sum / 3.0f)
+                  << ", min=" << min_val
+                  << ", max=" << max_val << std::endl;
+    }
+
+    std::cout << "\n=== Demo Complete ===" << std::endl;
+
+    return 0;
+}

--- a/include/eigenwave/concatenate.hpp
+++ b/include/eigenwave/concatenate.hpp
@@ -1,0 +1,296 @@
+#ifndef EIGENWAVE_CONCATENATE_HPP
+#define EIGENWAVE_CONCATENATE_HPP
+
+#include "tensor.hpp"
+#include <array>
+#include <algorithm>
+#include <numeric>
+#include <type_traits>
+
+namespace eigenwave {
+
+// ============================================================================
+// Helper templates for compile-time dimension validation
+// ============================================================================
+
+// Check if all tensors have the same shape except along a specific axis
+template<size_t Axis, typename... Tensors>
+struct can_concatenate;
+
+template<size_t Axis, typename T, size_t... Dims1, size_t... Dims2>
+struct can_concatenate<Axis, Tensor<T, Dims1...>, Tensor<T, Dims2...>> {
+    static constexpr size_t ndim1 = sizeof...(Dims1);
+    static constexpr size_t ndim2 = sizeof...(Dims2);
+    static constexpr std::array<size_t, ndim1> shape1 = {Dims1...};
+    static constexpr std::array<size_t, ndim2> shape2 = {Dims2...};
+
+    static constexpr bool value() {
+        if constexpr (ndim1 != ndim2) {
+            return false;
+        }
+        if constexpr (Axis >= ndim1) {
+            return false;
+        }
+        // Check all dimensions except the concatenation axis
+        for (size_t i = 0; i < ndim1; ++i) {
+            if (i != Axis && shape1[i] != shape2[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+// Variadic version for multiple tensors
+template<size_t Axis, typename T1, typename T2, typename T3, typename... Rest>
+struct can_concatenate<Axis, T1, T2, T3, Rest...> {
+    static constexpr bool value() {
+        return can_concatenate<Axis, T1, T2>::value() &&
+               can_concatenate<Axis, T1, T3, Rest...>::value();
+    }
+};
+
+// Helper to compute concatenated shape
+template<size_t Axis, typename... Tensors>
+struct concatenated_shape;
+
+template<size_t Axis, typename T, size_t... Dims1, size_t... Dims2>
+struct concatenated_shape<Axis, Tensor<T, Dims1...>, Tensor<T, Dims2...>> {
+    static constexpr std::array<size_t, sizeof...(Dims1)> shape1 = {Dims1...};
+    static constexpr std::array<size_t, sizeof...(Dims2)> shape2 = {Dims2...};
+
+    static constexpr auto compute() {
+        std::array<size_t, sizeof...(Dims1)> result = shape1;
+        result[Axis] += shape2[Axis];
+        return result;
+    }
+};
+
+// Helper to extract dimension at compile time
+template<size_t Idx, size_t... Values>
+struct get_at_index;
+
+template<size_t... Values>
+struct get_at_index<0, Values...> {
+    static constexpr size_t value = 0;  // Will be specialized
+};
+
+// ============================================================================
+// Concatenate implementation for 1D tensors
+// ============================================================================
+
+template<typename T, size_t D1, size_t D2>
+Tensor<T, D1 + D2> concatenate(const Tensor<T, D1>& t1, const Tensor<T, D2>& t2) {
+    Tensor<T, D1 + D2> result;
+
+    // Copy first tensor
+    std::copy(t1.begin(), t1.end(), result.begin());
+    // Copy second tensor
+    std::copy(t2.begin(), t2.end(), result.begin() + D1);
+
+    return result;
+}
+
+// Variadic version for multiple 1D tensors
+template<typename T, size_t D1, size_t D2, size_t D3, size_t... Rest>
+auto concatenate(const Tensor<T, D1>& t1, const Tensor<T, D2>& t2,
+                 const Tensor<T, D3>& t3, const Tensor<T, Rest>&... rest) {
+    auto first_concat = concatenate(t1, t2);
+    return concatenate(first_concat, t3, rest...);
+}
+
+// ============================================================================
+// Concatenate implementation for 2D tensors
+// ============================================================================
+
+// Concatenate along axis 0 (rows)
+template<typename T, size_t R1, size_t R2, size_t C>
+Tensor<T, R1 + R2, C> concatenate_axis0(const Tensor<T, R1, C>& t1,
+                                        const Tensor<T, R2, C>& t2) {
+    Tensor<T, R1 + R2, C> result;
+
+    // Copy first tensor
+    for (size_t i = 0; i < R1; ++i) {
+        for (size_t j = 0; j < C; ++j) {
+            result(i, j) = t1(i, j);
+        }
+    }
+
+    // Copy second tensor
+    for (size_t i = 0; i < R2; ++i) {
+        for (size_t j = 0; j < C; ++j) {
+            result(R1 + i, j) = t2(i, j);
+        }
+    }
+
+    return result;
+}
+
+// Concatenate along axis 1 (columns)
+template<typename T, size_t R, size_t C1, size_t C2>
+Tensor<T, R, C1 + C2> concatenate_axis1(const Tensor<T, R, C1>& t1,
+                                        const Tensor<T, R, C2>& t2) {
+    Tensor<T, R, C1 + C2> result;
+
+    for (size_t i = 0; i < R; ++i) {
+        // Copy from first tensor
+        for (size_t j = 0; j < C1; ++j) {
+            result(i, j) = t1(i, j);
+        }
+        // Copy from second tensor
+        for (size_t j = 0; j < C2; ++j) {
+            result(i, C1 + j) = t2(i, j);
+        }
+    }
+
+    return result;
+}
+
+// General 2D concatenate with axis template parameter
+template<size_t Axis, typename T, size_t... Dims1, size_t... Dims2>
+auto concatenate(const Tensor<T, Dims1...>& t1, const Tensor<T, Dims2...>& t2) {
+    static_assert(sizeof...(Dims1) == 2 && sizeof...(Dims2) == 2,
+                  "This overload is for 2D tensors");
+
+    if constexpr (Axis == 0) {
+        return concatenate_axis0(t1, t2);
+    } else if constexpr (Axis == 1) {
+        return concatenate_axis1(t1, t2);
+    } else {
+        static_assert(Axis < 2, "Axis must be 0 or 1 for 2D tensors");
+    }
+}
+
+// ============================================================================
+// Stack implementation - Creates a new axis
+// ============================================================================
+
+// Stack 1D tensors to create a 2D tensor
+template<typename T, size_t D>
+Tensor<T, 2, D> stack(const Tensor<T, D>& t1, const Tensor<T, D>& t2) {
+    Tensor<T, 2, D> result;
+
+    for (size_t j = 0; j < D; ++j) {
+        result(0, j) = t1(j);
+        result(1, j) = t2(j);
+    }
+
+    return result;
+}
+
+// Stack multiple 1D tensors
+template<typename T, size_t D, typename... Tensors>
+auto stack(const Tensor<T, D>& t1, const Tensor<T, D>& t2, const Tensors&... rest) {
+    static_assert((std::is_same_v<Tensors, Tensor<T, D>> && ...),
+                  "All tensors must have the same shape");
+
+    constexpr size_t num_tensors = 2 + sizeof...(rest);
+    Tensor<T, num_tensors, D> result;
+
+    // Copy first tensor
+    for (size_t j = 0; j < D; ++j) {
+        result(0, j) = t1(j);
+    }
+
+    // Copy second tensor
+    for (size_t j = 0; j < D; ++j) {
+        result(1, j) = t2(j);
+    }
+
+    // Helper to copy remaining tensors
+    size_t row_idx = 2;
+    ((void)([&](const auto& tensor) {
+        for (size_t j = 0; j < D; ++j) {
+            result(row_idx, j) = tensor(j);
+        }
+        ++row_idx;
+    }(rest)), ...);
+
+    return result;
+}
+
+// Stack 2D tensors to create a 3D tensor
+template<typename T, size_t R, size_t C>
+Tensor<T, 2, R, C> stack(const Tensor<T, R, C>& t1, const Tensor<T, R, C>& t2) {
+    Tensor<T, 2, R, C> result;
+
+    for (size_t i = 0; i < R; ++i) {
+        for (size_t j = 0; j < C; ++j) {
+            result(0, i, j) = t1(i, j);
+            result(1, i, j) = t2(i, j);
+        }
+    }
+
+    return result;
+}
+
+// ============================================================================
+// Convenience functions matching NumPy API
+// ============================================================================
+
+// Horizontal stack (column-wise concatenation for 2D)
+template<typename T, size_t... Dims1, size_t... Dims2>
+auto hstack(const Tensor<T, Dims1...>& t1, const Tensor<T, Dims2...>& t2) {
+    constexpr size_t ndim = sizeof...(Dims1);
+
+    if constexpr (ndim == 1) {
+        // For 1D, hstack is same as concatenate
+        return concatenate(t1, t2);
+    } else if constexpr (ndim == 2) {
+        // For 2D, concatenate along axis 1 (columns)
+        return concatenate<1>(t1, t2);
+    } else {
+        static_assert(ndim <= 2, "hstack currently supports only 1D and 2D tensors");
+    }
+}
+
+// Vertical stack (row-wise concatenation for 2D)
+template<typename T, size_t... Dims1, size_t... Dims2>
+auto vstack(const Tensor<T, Dims1...>& t1, const Tensor<T, Dims2...>& t2) {
+    constexpr size_t ndim1 = sizeof...(Dims1);
+    constexpr size_t ndim2 = sizeof...(Dims2);
+
+    if constexpr (ndim1 == 1 && ndim2 == 1) {
+        // For 1D tensors, vstack creates a new axis
+        static_assert(std::is_same_v<Tensor<T, Dims1...>, Tensor<T, Dims2...>>,
+                      "1D tensors must have the same shape for vstack");
+        return stack(t1, t2);
+    } else if constexpr (ndim1 == 2 && ndim2 == 2) {
+        // For 2D, concatenate along axis 0 (rows)
+        return concatenate<0>(t1, t2);
+    } else {
+        static_assert(ndim1 <= 2, "vstack currently supports only 1D and 2D tensors");
+    }
+}
+
+// Depth stack - stack along third axis
+template<typename T, size_t R, size_t C>
+Tensor<T, R, C, 2> dstack(const Tensor<T, R, C>& t1, const Tensor<T, R, C>& t2) {
+    Tensor<T, R, C, 2> result;
+
+    for (size_t i = 0; i < R; ++i) {
+        for (size_t j = 0; j < C; ++j) {
+            result(i, j, 0) = t1(i, j);
+            result(i, j, 1) = t2(i, j);
+        }
+    }
+
+    return result;
+}
+
+// Overload for 1D tensors (reshape to Nx1x2)
+template<typename T, size_t D>
+Tensor<T, D, 1, 2> dstack(const Tensor<T, D>& t1, const Tensor<T, D>& t2) {
+    Tensor<T, D, 1, 2> result;
+
+    for (size_t i = 0; i < D; ++i) {
+        result(i, 0, 0) = t1(i);
+        result(i, 0, 1) = t2(i);
+    }
+
+    return result;
+}
+
+} // namespace eigenwave
+
+#endif // EIGENWAVE_CONCATENATE_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ FetchContent_MakeAvailable(googletest)
 add_executable(test_tensor test_tensor.cpp)
 add_executable(test_slicing_broadcasting test_slicing_broadcasting.cpp)
 add_executable(test_broadcasting test_broadcasting.cpp)
+add_executable(test_concatenate test_concatenate.cpp)
 
 # Link against gtest and eigenwave
 target_link_libraries(test_tensor
@@ -37,8 +38,16 @@ target_link_libraries(test_broadcasting
     gtest
 )
 
+target_link_libraries(test_concatenate
+    PRIVATE
+    eigenwave
+    gtest_main
+    gtest
+)
+
 # Add test discovery
 include(GoogleTest)
 gtest_discover_tests(test_tensor)
 gtest_discover_tests(test_slicing_broadcasting)
 gtest_discover_tests(test_broadcasting)
+gtest_discover_tests(test_concatenate)

--- a/tests/test_concatenate.cpp
+++ b/tests/test_concatenate.cpp
@@ -1,0 +1,317 @@
+#include <gtest/gtest.h>
+#include <eigenwave/tensor.hpp>
+#include <eigenwave/concatenate.hpp>
+
+using namespace eigenwave;
+
+// Test fixture for concatenation tests
+class ConcatenateTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+};
+
+// ============================================================================
+// 1D Tensor Concatenation Tests
+// ============================================================================
+
+TEST_F(ConcatenateTest, Concatenate1D_Basic) {
+    Tensor<int, 3> t1{1, 2, 3};
+    Tensor<int, 2> t2{4, 5};
+
+    auto result = concatenate(t1, t2);
+    static_assert(std::is_same_v<decltype(result), Tensor<int, 5>>);
+
+    EXPECT_EQ(result(0), 1);
+    EXPECT_EQ(result(1), 2);
+    EXPECT_EQ(result(2), 3);
+    EXPECT_EQ(result(3), 4);
+    EXPECT_EQ(result(4), 5);
+}
+
+TEST_F(ConcatenateTest, Concatenate1D_Multiple) {
+    Tensor<float, 2> t1{1.0f, 2.0f};
+    Tensor<float, 3> t2{3.0f, 4.0f, 5.0f};
+    Tensor<float, 2> t3{6.0f, 7.0f};
+
+    auto result = concatenate(t1, t2, t3);
+    static_assert(std::is_same_v<decltype(result), Tensor<float, 7>>);
+
+    EXPECT_FLOAT_EQ(result(0), 1.0f);
+    EXPECT_FLOAT_EQ(result(1), 2.0f);
+    EXPECT_FLOAT_EQ(result(2), 3.0f);
+    EXPECT_FLOAT_EQ(result(3), 4.0f);
+    EXPECT_FLOAT_EQ(result(4), 5.0f);
+    EXPECT_FLOAT_EQ(result(5), 6.0f);
+    EXPECT_FLOAT_EQ(result(6), 7.0f);
+}
+
+TEST_F(ConcatenateTest, Concatenate1D_SingleElement) {
+    Tensor<int, 1> t1{42};
+    Tensor<int, 1> t2{99};
+
+    auto result = concatenate(t1, t2);
+    static_assert(std::is_same_v<decltype(result), Tensor<int, 2>>);
+
+    EXPECT_EQ(result(0), 42);
+    EXPECT_EQ(result(1), 99);
+}
+
+// ============================================================================
+// 2D Tensor Concatenation Tests
+// ============================================================================
+
+TEST_F(ConcatenateTest, Concatenate2D_Axis0) {
+    Tensor<int, 2, 3> t1{1, 2, 3,
+                         4, 5, 6};
+    Tensor<int, 1, 3> t2{7, 8, 9};
+
+    auto result = concatenate<0>(t1, t2);
+    static_assert(std::is_same_v<decltype(result), Tensor<int, 3, 3>>);
+
+    // Check first matrix rows
+    EXPECT_EQ(result(0, 0), 1);
+    EXPECT_EQ(result(0, 1), 2);
+    EXPECT_EQ(result(0, 2), 3);
+    EXPECT_EQ(result(1, 0), 4);
+    EXPECT_EQ(result(1, 1), 5);
+    EXPECT_EQ(result(1, 2), 6);
+
+    // Check appended row
+    EXPECT_EQ(result(2, 0), 7);
+    EXPECT_EQ(result(2, 1), 8);
+    EXPECT_EQ(result(2, 2), 9);
+}
+
+TEST_F(ConcatenateTest, Concatenate2D_Axis1) {
+    Tensor<int, 2, 2> t1{1, 2,
+                         3, 4};
+    Tensor<int, 2, 3> t2{5, 6, 7,
+                         8, 9, 10};
+
+    auto result = concatenate<1>(t1, t2);
+    static_assert(std::is_same_v<decltype(result), Tensor<int, 2, 5>>);
+
+    // Check first row
+    EXPECT_EQ(result(0, 0), 1);
+    EXPECT_EQ(result(0, 1), 2);
+    EXPECT_EQ(result(0, 2), 5);
+    EXPECT_EQ(result(0, 3), 6);
+    EXPECT_EQ(result(0, 4), 7);
+
+    // Check second row
+    EXPECT_EQ(result(1, 0), 3);
+    EXPECT_EQ(result(1, 1), 4);
+    EXPECT_EQ(result(1, 2), 8);
+    EXPECT_EQ(result(1, 3), 9);
+    EXPECT_EQ(result(1, 4), 10);
+}
+
+// ============================================================================
+// Stack Tests
+// ============================================================================
+
+TEST_F(ConcatenateTest, Stack1D_Basic) {
+    Tensor<float, 3> t1{1.0f, 2.0f, 3.0f};
+    Tensor<float, 3> t2{4.0f, 5.0f, 6.0f};
+
+    auto result = stack(t1, t2);
+    static_assert(std::is_same_v<decltype(result), Tensor<float, 2, 3>>);
+
+    // Check first row (from t1)
+    EXPECT_FLOAT_EQ(result(0, 0), 1.0f);
+    EXPECT_FLOAT_EQ(result(0, 1), 2.0f);
+    EXPECT_FLOAT_EQ(result(0, 2), 3.0f);
+
+    // Check second row (from t2)
+    EXPECT_FLOAT_EQ(result(1, 0), 4.0f);
+    EXPECT_FLOAT_EQ(result(1, 1), 5.0f);
+    EXPECT_FLOAT_EQ(result(1, 2), 6.0f);
+}
+
+TEST_F(ConcatenateTest, Stack1D_Multiple) {
+    Tensor<int, 2> t1{1, 2};
+    Tensor<int, 2> t2{3, 4};
+    Tensor<int, 2> t3{5, 6};
+
+    auto result = stack(t1, t2, t3);
+    static_assert(std::is_same_v<decltype(result), Tensor<int, 3, 2>>);
+
+    EXPECT_EQ(result(0, 0), 1);
+    EXPECT_EQ(result(0, 1), 2);
+    EXPECT_EQ(result(1, 0), 3);
+    EXPECT_EQ(result(1, 1), 4);
+    EXPECT_EQ(result(2, 0), 5);
+    EXPECT_EQ(result(2, 1), 6);
+}
+
+TEST_F(ConcatenateTest, Stack2D_Basic) {
+    Tensor<int, 2, 2> t1{1, 2,
+                         3, 4};
+    Tensor<int, 2, 2> t2{5, 6,
+                         7, 8};
+
+    auto result = stack(t1, t2);
+    static_assert(std::is_same_v<decltype(result), Tensor<int, 2, 2, 2>>);
+
+    // Check first matrix
+    EXPECT_EQ(result(0, 0, 0), 1);
+    EXPECT_EQ(result(0, 0, 1), 2);
+    EXPECT_EQ(result(0, 1, 0), 3);
+    EXPECT_EQ(result(0, 1, 1), 4);
+
+    // Check second matrix
+    EXPECT_EQ(result(1, 0, 0), 5);
+    EXPECT_EQ(result(1, 0, 1), 6);
+    EXPECT_EQ(result(1, 1, 0), 7);
+    EXPECT_EQ(result(1, 1, 1), 8);
+}
+
+// ============================================================================
+// Convenience Function Tests
+// ============================================================================
+
+TEST_F(ConcatenateTest, HStack1D) {
+    Tensor<double, 3> t1{1.0, 2.0, 3.0};
+    Tensor<double, 2> t2{4.0, 5.0};
+
+    auto result = hstack(t1, t2);
+    static_assert(std::is_same_v<decltype(result), Tensor<double, 5>>);
+
+    EXPECT_DOUBLE_EQ(result(0), 1.0);
+    EXPECT_DOUBLE_EQ(result(1), 2.0);
+    EXPECT_DOUBLE_EQ(result(2), 3.0);
+    EXPECT_DOUBLE_EQ(result(3), 4.0);
+    EXPECT_DOUBLE_EQ(result(4), 5.0);
+}
+
+TEST_F(ConcatenateTest, HStack2D) {
+    Tensor<int, 2, 2> t1{1, 2,
+                         3, 4};
+    Tensor<int, 2, 1> t2{5,
+                         6};
+
+    auto result = hstack(t1, t2);
+    static_assert(std::is_same_v<decltype(result), Tensor<int, 2, 3>>);
+
+    EXPECT_EQ(result(0, 0), 1);
+    EXPECT_EQ(result(0, 1), 2);
+    EXPECT_EQ(result(0, 2), 5);
+    EXPECT_EQ(result(1, 0), 3);
+    EXPECT_EQ(result(1, 1), 4);
+    EXPECT_EQ(result(1, 2), 6);
+}
+
+TEST_F(ConcatenateTest, VStack1D) {
+    Tensor<float, 3> t1{1.0f, 2.0f, 3.0f};
+    Tensor<float, 3> t2{4.0f, 5.0f, 6.0f};
+
+    auto result = vstack(t1, t2);
+    static_assert(std::is_same_v<decltype(result), Tensor<float, 2, 3>>);
+
+    EXPECT_FLOAT_EQ(result(0, 0), 1.0f);
+    EXPECT_FLOAT_EQ(result(0, 1), 2.0f);
+    EXPECT_FLOAT_EQ(result(0, 2), 3.0f);
+    EXPECT_FLOAT_EQ(result(1, 0), 4.0f);
+    EXPECT_FLOAT_EQ(result(1, 1), 5.0f);
+    EXPECT_FLOAT_EQ(result(1, 2), 6.0f);
+}
+
+TEST_F(ConcatenateTest, VStack2D) {
+    Tensor<int, 1, 3> t1{1, 2, 3};
+    Tensor<int, 2, 3> t2{4, 5, 6,
+                         7, 8, 9};
+
+    auto result = vstack(t1, t2);
+    static_assert(std::is_same_v<decltype(result), Tensor<int, 3, 3>>);
+
+    EXPECT_EQ(result(0, 0), 1);
+    EXPECT_EQ(result(0, 1), 2);
+    EXPECT_EQ(result(0, 2), 3);
+    EXPECT_EQ(result(1, 0), 4);
+    EXPECT_EQ(result(1, 1), 5);
+    EXPECT_EQ(result(1, 2), 6);
+    EXPECT_EQ(result(2, 0), 7);
+    EXPECT_EQ(result(2, 1), 8);
+    EXPECT_EQ(result(2, 2), 9);
+}
+
+TEST_F(ConcatenateTest, DStack2D) {
+    Tensor<int, 2, 2> t1{1, 2,
+                         3, 4};
+    Tensor<int, 2, 2> t2{5, 6,
+                         7, 8};
+
+    auto result = dstack(t1, t2);
+    static_assert(std::is_same_v<decltype(result), Tensor<int, 2, 2, 2>>);
+
+    // First depth slice
+    EXPECT_EQ(result(0, 0, 0), 1);
+    EXPECT_EQ(result(0, 1, 0), 2);
+    EXPECT_EQ(result(1, 0, 0), 3);
+    EXPECT_EQ(result(1, 1, 0), 4);
+
+    // Second depth slice
+    EXPECT_EQ(result(0, 0, 1), 5);
+    EXPECT_EQ(result(0, 1, 1), 6);
+    EXPECT_EQ(result(1, 0, 1), 7);
+    EXPECT_EQ(result(1, 1, 1), 8);
+}
+
+TEST_F(ConcatenateTest, DStack1D) {
+    Tensor<float, 3> t1{1.0f, 2.0f, 3.0f};
+    Tensor<float, 3> t2{4.0f, 5.0f, 6.0f};
+
+    auto result = dstack(t1, t2);
+    static_assert(std::is_same_v<decltype(result), Tensor<float, 3, 1, 2>>);
+
+    // Check reshaped structure
+    EXPECT_FLOAT_EQ(result(0, 0, 0), 1.0f);
+    EXPECT_FLOAT_EQ(result(0, 0, 1), 4.0f);
+    EXPECT_FLOAT_EQ(result(1, 0, 0), 2.0f);
+    EXPECT_FLOAT_EQ(result(1, 0, 1), 5.0f);
+    EXPECT_FLOAT_EQ(result(2, 0, 0), 3.0f);
+    EXPECT_FLOAT_EQ(result(2, 0, 1), 6.0f);
+}
+
+// ============================================================================
+// Edge Cases and Error Conditions
+// ============================================================================
+
+TEST_F(ConcatenateTest, EmptyConcat1D) {
+    Tensor<int, 0> empty;
+    Tensor<int, 3> t{1, 2, 3};
+
+    auto result = concatenate(empty, t);
+    static_assert(std::is_same_v<decltype(result), Tensor<int, 3>>);
+
+    EXPECT_EQ(result(0), 1);
+    EXPECT_EQ(result(1), 2);
+    EXPECT_EQ(result(2), 3);
+}
+
+TEST_F(ConcatenateTest, LargeConcatenation) {
+    Tensor<int, 100> t1 = Tensor<int, 100>::zeros();
+    Tensor<int, 200> t2 = Tensor<int, 200>::ones();
+
+    auto result = concatenate(t1, t2);
+    static_assert(std::is_same_v<decltype(result), Tensor<int, 300>>);
+
+    // Check first part is zeros
+    for (size_t i = 0; i < 100; ++i) {
+        EXPECT_EQ(result(i), 0);
+    }
+
+    // Check second part is ones
+    for (size_t i = 100; i < 300; ++i) {
+        EXPECT_EQ(result(i), 1);
+    }
+}
+
+// Test compile-time dimension validation
+// These should not compile (uncomment to test):
+// TEST_F(ConcatenateTest, InvalidDimensions) {
+//     Tensor<int, 2, 3> t1;
+//     Tensor<int, 2, 4> t2;
+//     // This should fail: cannot concatenate along axis 0 when axis 1 dimensions differ
+//     // auto result = concatenate<0>(t1, t2);
+// }


### PR DESCRIPTION
## Summary
This PR implements comprehensive tensor concatenation and stacking functionality, addressing one of the planned future enhancements listed in the README.

## Features Added
- **Concatenation**: Join tensors along existing axes
  - `concatenate()` - Works for 1D and 2D tensors
  - Supports multiple tensors in a single call
  - Compile-time dimension validation

- **Stacking**: Join tensors along a new axis
  - `stack()` - Creates new dimension for stacking
  - Works with 1D → 2D and 2D → 3D

- **NumPy-style convenience functions**:
  - `hstack()` - Horizontal concatenation
  - `vstack()` - Vertical stacking
  - `dstack()` - Depth stacking

## Implementation Details
- All operations use compile-time dimension checking
- Follows existing library patterns and conventions
- Zero runtime overhead for dimension validation
- Returns new tensors (no in-place operations)

## Testing
- Added comprehensive test suite with 16 tests
- Tests cover all operations and edge cases
- All existing tests still pass (58 total tests passing)

## Documentation
- Added new demo program (`concatenate_demo.cpp`) showing practical usage
- Updated README with API documentation and examples
- Removed "Tensor concatenation and stacking" from future enhancements

## Example Usage
```cpp
// 1D concatenation
Tensor<int, 3> vec1{1, 2, 3};
Tensor<int, 2> vec2{4, 5};
auto concat = concatenate(vec1, vec2);  // Shape: [5]

// 2D concatenation along different axes
Tensor<float, 2, 3> mat1{1, 2, 3, 4, 5, 6};
Tensor<float, 1, 3> mat2{7, 8, 9};
auto vconcat = concatenate<0>(mat1, mat2);  // Shape: [3, 3]

// Stacking creates new axis
Tensor<int, 3> v1{1, 2, 3};
Tensor<int, 3> v2{4, 5, 6};
auto stacked = stack(v1, v2);  // Shape: [2, 3]

// Convenience functions
auto h_result = hstack(vec1, vec2);
auto v_result = vstack(v1, v2);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)