### PR TITLE
test: Enable broadcasting incompatibility tests

### DIFF
--- a/tests/test_broadcasting.cpp
+++ b/tests/test_broadcasting.cpp
@@ -135,10 +135,9 @@ TEST_F(BroadcastViewTest, CanBroadcastCheck) {
     EXPECT_TRUE((can_broadcast_impl<3>::with<1>()));      // [3] and [1] compatible
     EXPECT_TRUE((can_broadcast_impl<1, 3>::with<3>()));   // [1, 3] and [3] compatible
 
-    // Incompatible shapes - temporarily disabled due to implementation issues
-    // TODO: Fix these once proper broadcasting is implemented
-    // EXPECT_FALSE((can_broadcast_impl<3>::with<2>()));     // [3] and [2] incompatible
-    // EXPECT_FALSE((can_broadcast_impl<2, 3>::with<3, 2>())); // [2, 3] and [3, 2] incompatible
+    // Incompatible shapes
+    EXPECT_FALSE((can_broadcast_impl<3>::with<2>()));     // [3] and [2] incompatible
+    EXPECT_FALSE((can_broadcast_impl<2, 3>::with<3, 2>())); // [2, 3] and [3, 2] incompatible
 }
 
 // Demonstrate memory efficiency of broadcasting


### PR DESCRIPTION
## Summary
- Re-enabled tests for broadcasting incompatibility checks
- The broadcasting implementation was already working correctly
- Tests now verify that incompatible shapes (e.g., [3] vs [2], [2,3] vs [3,2]) are properly rejected

## Test plan
- [x] All broadcasting tests pass
- [x] Verified incompatible shape detection works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)